### PR TITLE
Use 1M read buffer for significantly better performance.

### DIFF
--- a/bamfile.d
+++ b/bamfile.d
@@ -208,7 +208,7 @@ private:
     int[string] _reference_sequence_dict; /// name -> index mapping
 
     TaskPool _task_pool;
-    size_t buffer_size = 8192; // buffer size to be used for I/O
+    size_t buffer_size = 1048576; // buffer size to be used for I/O
 
 	// get decompressed stream out of compressed BAM file
 	IChunkInputStream getDecompressedStream() {


### PR DESCRIPTION
The current 8K read buffer size is suboptimal. By increasing it to 1 MB, performance can be increased significantly. In tests (running the "Output reads to BAM file" example code from [Getting Started](https://github.com/lomereiter/sambamba/wiki/Getting-started)) with a fully cached 206 MB file, the D code spent about 800 ms in read() calls with the default 8K buffer size. Increasing that to 1 MB cut this to about 74 ms.

Note that this was the best possible case, a file that was already fully cached in memory. With an uncached NFS-mounted file on SATA disks, for instance, the impact could be much more dramatic.

See the [performance data](https://gist.github.com/ebd12adebcdf5cd46d56) for details.
