### PR TITLE
Resolves

### DIFF
--- a/sambamba/utils/common/queryparser.d
+++ b/sambamba/utils/common/queryparser.d
@@ -438,7 +438,7 @@ final class QueryGrammar : Grammar!Node {
                 }
                 if (i == str.length && str[$ - 1] != '/') return pos;
                 while (i < str.length) {
-                    if (isWhite(str[i]) || str[i] == ')') break;
+                    if (std.ascii.isWhite(str[i]) || str[i] == ')') break;
                     if (canFind("gixUms", str[i])) {
                         ++i;
                     } else {


### PR DESCRIPTION
  sambamba/utils/common/queryparser.d(441): Error: std.ascii.isWhite at /usr/include/dmd/phobos/std/ascii.d(200) conflicts with std.uni.isWhite at /usr/include/dmd/phobos/std/uni.d(6417)

with dmd 2.064.2 on Debian.
