### PR TITLE
Sambamba sort: default tmpdir to /tmp

### DIFF
--- a/sambamba/sort.d
+++ b/sambamba/sort.d
@@ -89,7 +89,7 @@ class Sorter {
     BamReader bam;
     TaskPool task_pool;
     size_t memory_limit = 512 * 1024 * 1024;
-    string tmpdir = null;
+    string tmpdir = "/tmp";
     int compression_level = -1;
     bool uncompressed_chunks = false;
     string output_filename = null;


### PR DESCRIPTION
For similar behavior as sambamba markdup. 
