### PR TITLE
return 1 on error

### DIFF
--- a/sambamba/flagstat.d
+++ b/sambamba/flagstat.d
@@ -134,6 +134,7 @@ int flagstat_main(string[] args) {
         }
     } catch (Throwable e) {
         stderr.writeln(e.msg);
+        return 1;
     }
     return 0;
 }


### PR DESCRIPTION
flagstat is the only tool that isn't returning 1 when errors are encountered.  This adds the return 1 to the catch block.