### PR TITLE
make error message more informative

### DIFF
--- a/sambamba/sort.d
+++ b/sambamba/sort.d
@@ -604,7 +604,7 @@ size_t parseMemory(string str) {
         case "GB":
             return sz * 1_000_000_000;
         default:
-            throw new Exception("couldn't parse ", initial_str);
+            throw new Exception("couldn't parse --memory-limit option ", initial_str);
     }
 }
 


### PR DESCRIPTION
When one passes a float, let's say -m=2.5G the only message that is returned is: "sambamba-sort: couldn't parse ", which is not very informative, as this someone may blame the input BAM file and spend some time trying to figure out what is wrong with it. The updated error message points directly to the problem. That's a very little change that may save some time.