### PR TITLE
Always use Python 3+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
 After checking out the source from github with git submodules is is
 possibleto install the build tools with GNU Guix
 
-    guix package -i gcc-toolchain gdb bash ld-wrapper ldc which python2 git
+    guix package -i gcc-toolchain gdb bash ld-wrapper ldc which python3 git
 
 Even better, with Guix, you can create a light-weight container in the source tree
 and run our development setup (gold was added lately by ldc)

--- a/gen_ldc_version_info.py
+++ b/gen_ldc_version_info.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import re, sys, subprocess
 
 if len(sys.argv) < 2:

--- a/scripts/bioconda_push.sh
+++ b/scripts/bioconda_push.sh
@@ -2,7 +2,7 @@ RECIPES=~/github/bioconda-recipes # location of the cloned fork
 REMOTE=bioconda                   # bioconda/bioconda-recipes remote
 
 UPDATED_RECIPE=/tmp/sambamba.yaml
-python bioconda_yaml_gen.py > $UPDATED_RECIPE
+python3 bioconda_yaml_gen.py > $UPDATED_RECIPE
 VERSION=`grep version $UPDATED_RECIPE | cut -d\' -f2`
 
 cd $RECIPES

--- a/scripts/bioconda_yaml_gen.py
+++ b/scripts/bioconda_yaml_gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 template = """package:
   name: sambamba
   version: '{version}'

--- a/test/test_depth.py
+++ b/test/test_depth.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import msgpack
 
 import subprocess


### PR DESCRIPTION
Hi!
We are currently working on [removing Python 2](https://lists.debian.org/debian-python/2019/07/msg00080.html) from Debian, and all other Linux distributions are working on similar efforts.
While it's likely that at some point Debian will provide a "python" binary pointing to the latest Python version, for now "python" still means Py2 and that executable will likely be gone soon (hopefully in time for the next Debian release).

This patch makes Sambamba use python3 explicitly wherever possible.
I don't know much about Guix, so the Guix packages line may need to be adjusted differently (please have a look at that).

Cheers,
    Matthias
