### PR TITLE
Fix GNU Guix install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
 After checking out the source from github with git submodules is is
 possibleto install the build tools with GNU Guix
 
-    guix package -i gcc-toolchain gdb bash ld-wrapper ldc which python3 git
+    guix package -i gcc-toolchain gdb bash ld-wrapper ldc which python git
 
 Even better, with Guix, you can create a light-weight container in the source tree
 and run our development setup (gold was added lately by ldc)


### PR DESCRIPTION
This partially reverts https://github.com/biod/sambamba/pull/418 as [my suggestion there](https://github.com/biod/sambamba/pull/418/files#r358093099) was ignored before merging.

Also note that as of now, the `guix package` and `guix environment` calls don't match.