### PR TITLE
add missing standard SAM header tags

### DIFF
--- a/BioD/bio/std/hts/sam/header.d
+++ b/BioD/bio/std/hts/sam/header.d
@@ -215,12 +215,16 @@ private {
 
 mixin HeaderLineStruct!("HdLine", "@HD", null,
           Field!("format_version", "VN"),
-          Field!("sorting_order", "SO"));
+          Field!("grouping", "GO"),
+          Field!("sorting_order", "SO"),
+          Field!("sub_sorting_order", "SS"));
 
 mixin HeaderLineStruct!("SqLine", "@SQ", "name",
           Field!("name", "SN"),
           Field!("length", "LN", uint),
+          Field!("alternative_names", "AN"),
           Field!("assembly", "AS"),
+          Field!("description", "DS"),
           Field!("md5", "M5"),
           Field!("species", "SP"),
           Field!("uri", "UR"),
@@ -228,6 +232,7 @@ mixin HeaderLineStruct!("SqLine", "@SQ", "name",
 
 mixin HeaderLineStruct!("RgLine", "@RG", "identifier",
           Field!("identifier", "ID"),
+          Field!("barcode", "BC"),
           Field!("sequencing_center", "CN"),
           Field!("description", "DS"),
           Field!("date", "DT"),


### PR DESCRIPTION
This PR adds missing standard header tags which are listed in the current (as of January, 2021) SAM specification (http://samtools.github.io/hts-specs/SAMv1.pdf).

Fixes #462 but does not allow "freely add new tags for further data fields", as it is allowed by the SAM specification.