### PR TITLE
disable linking of default shared libs on static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ coverage:                          DFLAGS += -cov
 
 release static pgo-static:         DFLAGS += -O3 -release -enable-inlining -boundscheck=off -L-lz
 
-static:                            DFLAGS += -static -L-Bstatic
+static:                            DFLAGS += -static -L-Bstatic -link-defaultlib-shared=false
 
 pgo-static:                        DFLAGS += -fprofile-instr-use=profile.data
 


### PR DESCRIPTION
In some environments (i. e. Ubuntu 18.04 and 20.04 with LDC v1.8) `make static` fails with the following error message:

```
Error: Can't use -link-defaultlib-shared and -static together
Makefile:89: recipe for target 'singleobj' failed
make: *** [singleobj] Error 1
```

This PR just disables the linking of default shared libs, which is intentional on static builds.