### PR TITLE
Support filtering of absolute template length

### DIFF
--- a/sambamba/utils/common/filtering.d
+++ b/sambamba/utils/common/filtering.d
@@ -32,6 +32,7 @@ import std.range;
 import std.algorithm;
 import std.array;
 import std.string : representation;
+import std.math;
 
 auto filtered(R)(R reads, Filter f) {
     return reads.zip(f.repeat()).filter!q{a[1].accepts(a[0])}.map!"a[0]"();
@@ -207,7 +208,7 @@ final class IntegerFieldFilter(string op) : Filter {
             case "sequence_length": mixin("return a.sequence_length " ~ op ~ "_value;");
             case "mate_ref_id": mixin("return a.mate_ref_id " ~ op ~ "_value;");
             case "mate_position": mixin("return a.mate_position " ~ op ~ "_value;");
-            case "template_length": mixin("return a.template_length " ~ op ~ "_value;");
+            case "template_length": mixin("return abs(a.template_length) " ~ op ~ "_value;");
             default: throw new Exception("unknown integer field '" ~ _fieldname ~ "'");
         }
     }


### PR DESCRIPTION
This PR adds support for filtering absolute template length. 

Currently, only positive template length values can be filtered, i. e. with `sambamba view -S -F "template_length < 8000"`. Using `"template_length < 8000 AND template_length > -8000"` results in the following error:

```
sambamba-view: invalid symbol in input stream at position 23
```

The PR computes the absolute value of the template_length before comparison.