### PR TITLE
Made compile with removed alias this in Nullable

### DIFF
--- a/BioD/bio/std/experimental/hts/pileup.d
+++ b/BioD/bio/std/experimental/hts/pileup.d
@@ -271,14 +271,14 @@ class PileUp(R) {
   }
   ref R read_current() {
     enforce(!current.isNull, "current should be set for PileUp.read_current");
-    return read(current);
+    return read(current.get);
   }
   bool is_at_end(RingBufferIndex idx) { return ring.is_tail(idx); }
 
   @property void current_inc() {
     asserte(!empty);
-    asserte(!ring.is_tail(current));
-    ++current;
+    asserte(!ring.is_tail(current.get));
+    ++current.get;
   }
 
   @property void set_current_to_head() {
@@ -290,7 +290,7 @@ class PileUp(R) {
   }
 
   @property bool current_is_tail() {
-    return ring.is_tail(current);
+    return ring.is_tail(current.get);
   }
 
   void each(void delegate(R) dg) {

--- a/sambamba/markdup.d
+++ b/sambamba/markdup.d
@@ -504,8 +504,8 @@ struct CollateReadPairRange(R, bool keepFragments, alias charsHashFunc)
     void popFrontTempFiles() {
         while (!_tmp_reads.empty) {
             auto r2 = next(_tmp_reads);
-            if (readsArePaired(_tmp_r1, r2)) {
-                _front = FrontType(_tmp_r1, r2);
+            if (readsArePaired(_tmp_r1.get, r2)) {
+                _front = FrontType(_tmp_r1.get, r2);
                 if (!_tmp_reads.empty)
                     _tmp_r1 = next(_tmp_reads);
                 else
@@ -513,7 +513,7 @@ struct CollateReadPairRange(R, bool keepFragments, alias charsHashFunc)
                 return;
             } else {
                 static if (keepFragments) {
-                    _front = FrontType(_tmp_r1);
+                    _front = FrontType(_tmp_r1.get);
                     _tmp_r1 = r2;
                     return;
                 } else {
@@ -523,7 +523,7 @@ struct CollateReadPairRange(R, bool keepFragments, alias charsHashFunc)
         }
 
         if (!_tmp_r1.isNull) {
-            _front = FrontType(_tmp_r1);
+            _front = FrontType(_tmp_r1.get);
             _tmp_r1.nullify();
             return;
         }
@@ -1050,7 +1050,7 @@ auto getDuplicateOffsets(R)(R reads, ReadGroupIndex rg_index,
                                        cfg.tmpdir, pool)) {
         auto end1 = collectSingleEndInfo(pf.read1, rg_index);
         if (!pf.read2.isNull) {
-            auto end2 = collectSingleEndInfo(pf.read2, rg_index);
+            auto end2 = collectSingleEndInfo(pf.read2.get, rg_index);
             auto pair = combine(end1, end2);
             paired_ends.put(pair);
             second_ends.put(end2.basic_info);

--- a/sambamba/pileup.d
+++ b/sambamba/pileup.d
@@ -429,28 +429,28 @@ class ChunkDispatcher(ChunkRange) {
         }
 
         if (num_ > 1) {
-            ulong diff = chunk[0].end_position - chunk[0].start_position;
-            int ref_id = chunk[0].ref_id;
-            if (ref_id == prev_ref_id && !chunk[0].front.reads.empty &&
-                prev_pos_diff + diff < chunk[0].front.reads[0].sequence_length) // assume reads are ~same length
+            ulong diff = chunk.get[0].end_position - chunk.get[0].start_position;
+            int ref_id = chunk.get[0].ref_id;
+            if (ref_id == prev_ref_id && !chunk.get[0].front.reads.empty &&
+                prev_pos_diff + diff < chunk.get[0].front.reads[0].sequence_length) // assume reads are ~same length
                 stderr.writeln("[WARNING] COVERAGE IS TOO HIGH, INCREASE --buffer-size TO AVOID WRONG RESULTS");
             prev_pos_diff = diff;
             prev_ref_id = ref_id;
         }
 
-        auto ref_name = bam_.reference_sequences[chunk[0].ref_id].name;
+        auto ref_name = bam_.reference_sequences[chunk.get[0].ref_id].name;
         auto f = std.stdio.File(filename ~ ".bed", "w");
         if (bed_filename is null) {
-            auto start = chunk[0].start_position;
-            auto end = chunk[0].end_position;
+            auto start = chunk.get[0].start_position;
+            auto end = chunk.get[0].end_position;
 
             auto bed = BedRecord(ref_name, start, end);
             f.writeln(bed);
         } else {
             foreach (reg; regions) {
-                if (chunk[0].ref_id != reg.ref_id) continue;
-                auto start = max(reg.start, chunk[0].start_position);
-                auto end = min(reg.end, chunk[0].end_position);
+                if (chunk.get[0].ref_id != reg.ref_id) continue;
+                auto start = max(reg.start, chunk.get[0].start_position);
+                auto end = min(reg.end, chunk.get[0].end_position);
                 if (start > end) continue;
                 auto bed = BedRecord(ref_name, start, end);
                 f.writeln(bed);
@@ -525,9 +525,9 @@ void worker(Dispatcher)(Dispatcher d,
         if (result.isNull)
             return;
 
-        auto chunk = result[0];
-        auto filename = result[1];
-        auto num = result[2];
+        auto chunk = result.get[0];
+        auto filename = result.get[1];
+        auto num = result.get[2];
         makeFifo(filename);
 
         import core.sys.posix.signal;

--- a/sambamba/subsample.d
+++ b/sambamba/subsample.d
@@ -243,7 +243,7 @@ void foreach_invalid_read(ref BamBlobReader reader, void delegate(ProcessReadBlo
 
 // ---- When current is unmapped, move through reads that are ignored.
 void foreach_outside_read(ref BamBlobReader reader, void delegate(ProcessReadBlob) dg) {
-  if (reader.peek.is_unmapped) {
+  if (reader.peek.get.is_unmapped) {
     foreach_invalid_read(reader,dg);
   }
 }
@@ -384,13 +384,13 @@ int subsample_main(string[] args) {
        }
       if (!pileup.empty) {
         auto read = reader.peek;
-        if (read.is_mapped && depth.ref_id != read.refid) {
+        if (read.get.is_mapped && depth.ref_id != read.get.refid) {
           // moving into a new pileup
           pileup.purge( (ReadState read) {
               write(",");
               writer.push(read.read);
             });
-          depth.reset(read.refid);
+          depth.reset(read.get.refid);
         }
       }
 


### PR DESCRIPTION
Motivation: I want to update LDC in Nix package repository.

The `alias this` of `std.typecons.Nullable` has been removed and now explicit `.get`s are required.