### PR TITLE
Add CI config for Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,79 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  LDC_VERSION: 1.30.0
+
+jobs:
+  build:
+    name: Build x86_64
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install build dependencies
+        run: |
+          set -x
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y liblz4-dev
+          ARCH=$(uname -m)
+          wget --quiet https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/ldc2-${LDC_VERSION}-linux-${ARCH}.tar.xz
+          tar xf ldc2-${LDC_VERSION}-linux-${ARCH}.tar.xz
+          echo "ldc2-${LDC_VERSION}-linux-${ARCH}/bin" >> $GITHUB_PATH
+
+      - name: Build & test
+        run:  make -j2 check
+      
+      - name: Create artifact
+        run: |
+          VERSION=$(cat VERSION)
+          mkdir artifact
+          gzip --stdout bin/sambamba-${VERSION} > artifact/sambamba-${VERSION}-linux-amd64-static.gz
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: sambamba-binary-archives
+          path: artifact
+
+  
+  build-aarch64:
+    name: Build aarch64
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: --volume "${PWD}:/sambamba"
+        install: |
+          set -x
+          apt-get update -q -y
+          apt-get install -qq -y gcc g++ wget file xz-utils tar liblz4-dev make python3 libxml2-dev libz-dev
+          ARCH=$(uname -m)
+          wget --quiet https://github.com/ldc-developers/ldc/releases/download/v${{ env.LDC_VERSION }}/ldc2-${{ env.LDC_VERSION }}-linux-${ARCH}.tar.xz
+          tar xf ldc2-${{ env.LDC_VERSION }}-linux-${ARCH}.tar.xz
+          echo "export PATH=$PWD/ldc2-${{ env.LDC_VERSION }}-linux-${ARCH}/bin:$PATH" >> $HOME/.env
+        run: |
+          set -x
+          source $HOME/.env
+          cd /sambamba
+          make -j2 check
+          VERSION=$(cat VERSION)
+          file bin/sambamba-${VERSION}
+          mkdir artifact
+          gzip --stdout bin/sambamba-${VERSION} > artifact/sambamba-${VERSION}-linux-arm64-static.gz
+      
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: sambamba-binary-archives
+        path: artifact


### PR DESCRIPTION
It seems [TravisCI](https://app.travis-ci.com/github/biod/sambamba) hasn't be used since 6d6295de45e5561936894692bb8afa8c9a233cba (May 22 2021), i.e. around 30 commits have been not tested!

With this PR I suggest moving to Github Actions.
The benefits are:
1) TravisCI is no more free for open source projects
2) Github Actions (GHA) is maintained better. There are many "actions" provided by the community
3) it could be used to release binaries for x86_64, aarch64 and more. The non-x86_64 builds are run on QEMU but this seems to be working quite well for Sambamba!

A green build could be seen in my fork - https://github.com/martin-g/sambamba/actions/runs/3250757265
And binary artifacts at https://github.com/martin-g/sambamba/suites/8778990966/artifacts/398461533

With the help of this [action](https://github.com/actions/upload-release-asset) one could even make Github releases. Please let me know and I could extend this PR or create a new one if you want to use it!
